### PR TITLE
feat: add keyboard navigation for Add to Album dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Synology didn’t add them. This extension does.
 - `Shift + R`: Rotate clockwise
 - `Shift + D`: Download (original, not compressed)
 - `Shift + T`: Add tags
+- `Shift + P`: Tag people
 - `Shift + A`: Add to album
 - `Shift + Tab`: Switch folder / timeline view
 - `1` - `5`: Rate photo (1-5 stars)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Synology didn’t add them. This extension does.
 - `Shift + T`: Add tags
 - `Shift + A`: Add to album
 - `Shift + Tab`: Switch folder / timeline view
-- (NEW) `1` - `5`: Rate photo (1-5 stars)
+- `1` - `5`: Rate photo (1-5 stars)
+
+**Inside the Add to Album dialog:**
+- `a`-`z`: Jump to the first album starting with that letter (or the next alphabetically if none match)
+- `↑` / `↓`: Navigate albums (wraps from last to first and vice versa) — each album is selected as you land on it
+- `Enter`: Confirm add to Album (click OK)
 
 If any shortcut stops working, just create an issue on GitHub and I’ll fix it as soon as I can.

--- a/content.js
+++ b/content.js
@@ -159,12 +159,19 @@ function confirmOk() {
   return false;
 }
 
+// Action: Tag People (Shift + P)
+function tagPeople() {
+  const button = findButton('button.synofoto-menu-text-button', 'Tag people');
+  if (button) button.click();
+}
+
 // Map key to actions (Shift + {Key})
 const actions = {
   'T': addTags,
   'R': rotate,
   'A': addToAlbum,
   'D': download,
+  'P': tagPeople,
   'Tab': changeView,
   'Delete': deleteDialog,
   'Backspace': deleteDialog,

--- a/content.js
+++ b/content.js
@@ -98,6 +98,67 @@ function ratePhoto(rating) {
   }
 }
 
+// --- Album dialog navigation ---
+
+let _albumNavIndex = -1;
+
+function getAlbumItems() {
+  return Array.from(document.querySelectorAll(
+    '.synofoto-album-list-item, .synofoto-album-list-item-selected'
+  )).filter(item => item.querySelector('.synofoto-album-list-name'));
+}
+
+function isAlbumDialogOpen() {
+  return getAlbumItems().length > 0;
+}
+
+function selectAlbumItem(item) {
+  item.click();
+  item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+}
+
+function navigateAlbumByLetter(letter) {
+  const items = getAlbumItems();
+  if (items.length === 0) return false;
+
+  const names = items.map(item =>
+    item.querySelector('.synofoto-album-list-name').textContent.trim().toLowerCase()
+  );
+  const lowerLetter = letter.toLowerCase();
+
+  let targetIndex = names.findIndex(name => name.startsWith(lowerLetter));
+  if (targetIndex === -1) {
+    targetIndex = names.findIndex(name => name > lowerLetter);
+  }
+  if (targetIndex === -1) targetIndex = 0;
+
+  _albumNavIndex = targetIndex;
+  selectAlbumItem(items[targetIndex]);
+  return true;
+}
+
+function navigateAlbumByArrow(direction) {
+  const items = getAlbumItems();
+  if (items.length === 0) { _albumNavIndex = -1; return false; }
+
+  if (_albumNavIndex === -1) {
+    _albumNavIndex = direction === 'down' ? 0 : items.length - 1;
+  } else {
+    _albumNavIndex = direction === 'down' ? _albumNavIndex + 1 : _albumNavIndex - 1;
+    _albumNavIndex = ((_albumNavIndex % items.length) + items.length) % items.length;
+  }
+
+  selectAlbumItem(items[_albumNavIndex]);
+  return true;
+}
+
+// Action: Confirm OK dialog (Enter)
+function confirmOk() {
+  const okButton = findButton('button.synofoto-text-button', 'OK');
+  if (okButton) { okButton.click(); return true; }
+  return false;
+}
+
 // Map key to actions (Shift + {Key})
 const actions = {
   'T': addTags,
@@ -117,6 +178,20 @@ document.addEventListener('keydown', (event) => {
       || event.target.isContentEditable
   ) return;
 
+  // Album dialog navigation — intercept before all other shortcuts
+  if (isAlbumDialogOpen() && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      navigateAlbumByArrow(event.key === 'ArrowDown' ? 'down' : 'up');
+      return;
+    }
+    if (event.key.length === 1 && /[a-zA-Z]/.test(event.key)) {
+      event.preventDefault();
+      navigateAlbumByLetter(event.key);
+      return;
+    }
+  }
+
   if (event.shiftKey) {
     const action = actions[event.key];
     if (action) {
@@ -132,6 +207,12 @@ document.addEventListener('keydown', (event) => {
   if (selectAllKey && event.key === 'a') {
     event.preventDefault(); // Prevent the default browser "select all" behavior
     selectAll(); // Run our custom "Select All" function
+  }
+
+  // Confirm OK dialog
+  if (event.key === 'Enter' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+    const handled = confirmOk();
+    if (handled) event.preventDefault();
   }
 
   // Rating shortcuts


### PR DESCRIPTION
## What this adds

Keyboard navigation for the **Add to Album** dialog:

- **Letter keys (a–z)**: jump to the first album starting with that letter, or the next album alphabetically if no exact match exists
- **↑ / ↓ arrow keys**: navigate through the album list with wrap-around (last→first and first→last); each album is selected as you land on it
- **Enter**: confirm "Add to Album" (clicks OK)

## Implementation notes

- Navigation auto-selects albums on arrival by dispatching a click, which triggers the class change (`synofoto-album-list-item` → `synofoto-album-list-item-selected`) that React listens to — enabling the OK button
- Position is tracked with a stable index variable (`_albumNavIndex`) rather than `document.activeElement`, because React replaces DOM nodes on re-render after each click, which would otherwise cause stale reference bugs and reset navigation to the start of the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)